### PR TITLE
reswall_multilayers.py deprecated complex update

### DIFF
--- a/pycolleff/pycolleff/impedances/reswall_multilayers.py
+++ b/pycolleff/pycolleff/impedances/reswall_multilayers.py
@@ -166,8 +166,8 @@ def prepare_inputs_epr_mur(w, epb, mub, ange, angm, sigmadc, tau):
         mur (numpy.ndarray, (M, N)): relative complex permeability.
 
     """
-    epr = _np.zeros((len(epb), len(w)), dtype=_np.complex)
-    mur = _np.zeros((len(epb), len(w)), dtype=_np.complex)
+    epr = _np.zeros((len(epb), len(w)), dtype=complex)
+    mur = _np.zeros((len(epb), len(w)), dtype=complex)
     for j in range(len(epb)):
         epr[j] = epb[j]*(1 - 1j*_np.sign(w)*_np.tan(ange[j]))
         mur[j] = mub[j]*(1 - 1j*_np.sign(w)*_np.tan(angm[j]))
@@ -343,8 +343,8 @@ def _round_alpha_tm(m, epr, mur, bet, nu, b):
     for i in range(len(b)):
         x = nu[i+1] * b[i]
         y = nu[i] * b[i]
-        Mt = _np.zeros((4, 4, nu.shape[1]), dtype=_np.complex)
-        D = _np.zeros((4, 4, nu.shape[1]), dtype=_np.complex)
+        Mt = _np.zeros((4, 4, nu.shape[1]), dtype=complex)
+        D = _np.zeros((4, 4, nu.shape[1]), dtype=complex)
 
         kmx = _kve(m, x)
         kmy = _kve(m, y)

--- a/pycolleff/pycolleff/longitudinal_equilibrium.py
+++ b/pycolleff/pycolleff/longitudinal_equilibrium.py
@@ -525,7 +525,7 @@ class LongitudinalEquilibrium:
         """."""
         if w is None:
             w = self._create_freqs()
-        total_zl = _np.zeros(w.shape, dtype=_np.complex)
+        total_zl = _np.zeros(w.shape, dtype=complex)
         imp_idx = self._get_impedance_types_idx()
         for iidx in imp_idx:
             imp = self.impedance_sources[iidx]
@@ -605,7 +605,7 @@ class LongitudinalEquilibrium:
         zl_wp *= zl_wps[:, None].conj()
 
         expph = _ne.evaluate('exp(-ps*zn_ph)')
-        harm_volt = _np.zeros((h, zgrid.size), dtype=_np.complex)
+        harm_volt = _np.zeros((h, zgrid.size), dtype=complex)
         for idx, p in enumerate(ps):
             dist_fourier = self.calc_fourier_transform(w=p*w0, dist=dist)
 
@@ -668,7 +668,7 @@ class LongitudinalEquilibrium:
         if self._exp_z is None:
             self._exp_z = _ne.evaluate('exp(beta*zgrid)')[None, :]
 
-        dist_exp_z = _np.zeros(dist.shape, dtype=_np.complex)
+        dist_exp_z = _np.zeros(dist.shape, dtype=complex)
         dist_exp_z += dist
         dist_exp_z *= fillpattern
         dist_exp_z *= self._exp_z


### PR DESCRIPTION
np.complex was deprecated, hence reswall_multilayers.py was updated with "complex" instead of "np.complex".