### PR TITLE
Fix Resistive Wall Impedance calculation on Mac and Windows.

### DIFF
--- a/pycolleff/pycolleff/impedances/conv_wake_impedance.py
+++ b/pycolleff/pycolleff/impedances/conv_wake_impedance.py
@@ -98,7 +98,7 @@ def from_impedance_to_wake(
 
     # I neet to take the conjugate of the impedance here, because the
     # convention adopted by ref[1] is different than the one we consider here.
-    Z = _np.array(Z.conj(), dtype=_np.complex256)
+    Z = _np.array(Z.conj(), dtype=complex)
 
     if interp_type.lower().startswith('spline'):
         interp = _Spline(w, Z, bc_type='not-a-knot')
@@ -170,8 +170,8 @@ def _integral_funcs(x):
     x_ser = x[iser]  # series
     x_for = x[ifor]  # formula
 
-    phi = _np.zeros(x.shape, dtype=_np.complex256)
-    psi = _np.zeros(x.shape, dtype=_np.complex256)
+    phi = _np.zeros(x.shape, dtype=complex)
+    psi = _np.zeros(x.shape, dtype=complex)
 
     # The exact formula is taken from ref. [1], eqs. E.142 and E.143
     exp = _np.exp(1j*x_for)
@@ -196,7 +196,7 @@ def _integral_funcs(x):
     for i in range(1000):
         log_conv += _np.log(absx/(i+1))
         if not i:
-            term = _np.ones(x_ser.shape, dtype=_np.complex256)
+            term = _np.ones(x_ser.shape, dtype=complex)
         else:
             term *= 1j*x_ser/i
         add = term / (i+3) / (i+4)

--- a/pycolleff/pycolleff/impedances/reswall_multilayers.py
+++ b/pycolleff/pycolleff/impedances/reswall_multilayers.py
@@ -801,7 +801,8 @@ def _debug_flat_calc_integrand(
 
 
 def _flat_integrand_arb_prec(u, kovgamma=1, is_in_t=False, **kwrgs):
-    _mpmath.mp.dps = kwrgs['prec']  # necessary for Mac and Windows systems.
+    _mpmath.mp.dps = kwrgs.pop('prec')  # Needed for Mac and Windows systems.
+
     if is_in_t:
         t, u = u, (1 - u) / u
     u = _mpf(u)

--- a/pycolleff/pycolleff/impedances/reswall_multilayers.py
+++ b/pycolleff/pycolleff/impedances/reswall_multilayers.py
@@ -721,6 +721,7 @@ def _flat_calc_alphas(
             murd=murd[i],
             nud=nud,
             bd=bd,
+            prec=_mpmath.mp.dps,  # needed for child processes in quad_vec
         )
 
         # The output of this integration is in standard precision:
@@ -785,6 +786,7 @@ def _debug_flat_calc_integrand(
         murd=murd,
         nud=nud,
         bd=bd,
+        prec=_mpmath.mp.dps,
     )
 
     alpha00 = _np.zeros(u.shape, dtype=complex)
@@ -799,6 +801,7 @@ def _debug_flat_calc_integrand(
 
 
 def _flat_integrand_arb_prec(u, kovgamma=1, is_in_t=False, **kwrgs):
+    _mpmath.mp.dps = kwrgs['prec']  # necessary for Mac and Windows systems.
     if is_in_t:
         t, u = u, (1 - u) / u
     u = _mpf(u)


### PR DESCRIPTION
We need to set the precision of `mpmath` library in child processes due to how the multiprocessing library spawns child processes.

Not setting this value was causing errors in Mac and Windows systems.